### PR TITLE
Fix flake8 lint violations

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,22 +1,36 @@
 from datetime import datetime
-import skimage as ski
+import os
+import sys
+
 import matplotlib.pyplot as plt
+import skimage as ski
 from scipy import ndimage as ndi
-import sys, os
+
 
 class BioCellRedEdgeDetection:
 
     def __init__(self, cells_image):
         self.cells_image = cells_image
-    
+
     def process_cell_image(self):
-        binary, dilate, fill, grayscale, overlay, red_noise, sobel_edge = self.build_output_image()
+        (
+            binary,
+            dilate,
+            fill,
+            grayscale,
+            overlay,
+            red_noise,
+            sobel_edge,
+        ) = self.build_output_image()
 
         # configure layout and save result
-        self.set_result_image_layout(binary, dilate, fill, grayscale, overlay, red_noise, sobel_edge)
+        self.set_result_image_layout(
+            binary, dilate, fill, grayscale, overlay, red_noise, sobel_edge
+        )
 
-
-    def set_result_image_layout(self, binary, dilate, fill, grayscale, overlay, red_noise, sobel_edge):
+    def set_result_image_layout(
+        self, binary, dilate, fill, grayscale, overlay, red_noise, sobel_edge
+    ):
         fig, axes = plt.subplots(4, 2)
         print("Set original image to output")
         axes[0, 0].imshow(self.cells_image)
@@ -41,27 +55,33 @@ class BioCellRedEdgeDetection:
         axes[3, 0].set_title('7. Dilate Image')
         print("Set overlay / final image to output")
         axes[3, 1].imshow(overlay, cmap=plt.cm.gray)
-        axes[3, 1].set_title('8. Overlay Original Image with \n Segmented Cells From Dilated Image')
+        axes[3, 1].set_title(
+            '8. Overlay Original Image with \n Segmented Cells From Dilated Image'
+        )
 
         plt.tight_layout()
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         output_file_name = f"output/result_{timestamp}.png"
         plt.savefig(output_file_name)
-        print("Image processing complete, please see results at: %s" % os.path.join(os.getcwd(), output_file_name))
+        print(
+            "Image processing complete, please see results at: %s"
+            % os.path.join(os.getcwd(), output_file_name)
+        )
         plt.show()
-
 
     def build_output_image(self):
         grayscale = ski.color.rgb2gray(self.cells_image)
         sobel_edge = ski.filters.roberts(grayscale)
         thresh = ski.filters.threshold_triangle(sobel_edge)
-        red_noise = ski.restoration.denoise_tv_chambolle(sobel_edge, weight=0.01, channel_axis=-1)
+        red_noise = ski.restoration.denoise_tv_chambolle(
+            sobel_edge, weight=0.01, channel_axis=-1
+        )
         binary = thresh < red_noise
         fill = ndi.binary_fill_holes(binary)
         dilate = ski.morphology.binary_dilation(fill)
         overlay = ski.color.label2rgb(dilate, image=self.cells_image, bg_label=0)
         return binary, dilate, fill, grayscale, overlay, red_noise, sobel_edge
-       
+
 
 if __name__ == '__main__':
     print("The name of the program is: %s" % sys.argv[0])
@@ -69,7 +89,7 @@ if __name__ == '__main__':
     file_path = str(sys.argv[1])
     print("The file for processing is located at: %s" % file_path)
 
-    cells_image = ski.io.imread(file_path)[:,:,:3]
+    cells_image = ski.io.imread(file_path)[:, :, :3]
 
     bioCellRedEdgeDetection = BioCellRedEdgeDetection(cells_image)
     bioCellRedEdgeDetection.process_cell_image()

--- a/main_test.py
+++ b/main_test.py
@@ -1,8 +1,11 @@
 import pytest
 import subprocess
 
+
 def test_main():
-  try:
-    subprocess.run(["python", "main.py", "input/original image cropped.png"])
-  except Exception as e:
-    pytest.fail(f"An error occurred: {e}")
+    try:
+        subprocess.run(
+            ["python", "main.py", "input/original image cropped.png"]
+        )
+    except Exception as e:
+        pytest.fail(f"An error occurred: {e}")


### PR DESCRIPTION
## Summary
- split combined imports and clean up blank-line/whitespace issues
- fix tuple slicing spacing and test indentation
- wrap long lines while preserving behavior

## Verification
- python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
- python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
- python -m pytest -s

Fixes #33